### PR TITLE
Trying to fix Registrator.jl error

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.9.2"
 manifest_format = "2.0"
-project_hash = "b226239d94f08c8789d10b824c47ad0985cbc9ac"
+project_hash = "0c103b35b31d4b816b30456238e69d1e5e073d25"
 
 [[deps.ANSIColoredPrinters]]
 git-tree-sha1 = "574baf8110975760d391c710b6341da1afa48d8c"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["fercarozzi <carozzi@ualberta.ca>"]
 version = "0.1.1"
 
 [deps]
+Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterTools = "35a29f4d-8980-5a13-9543-d66fff28ecb8"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,9 +1,8 @@
-using Pkg
-using PyCall
-
-if lowercase(get(ENV, "CI", "false")) == "true"
-
-    ENV["PYTHON"] = ""
-    Pkg.build("PyCall")
-
-end
+import Pkg, Conda
+@info "building!"
+Conda.pip_interop(true)
+Conda.pip("install", "matplotlib")
+Conda.add("matplotlib")
+ENV["PYTHON"] = joinpath(Conda.ROOTENV, "bin", "python")
+Pkg.build("PyCall")
+@info "built PyCall!"


### PR DESCRIPTION
This error happens when trying to automerge the new release:

```
┌ Info: Compat (with upper bound) for all dependencies
│   meets_this_guideline = true
└   message = ""
┌ Info: If it is a patch release on a post-1.0 package, then it does not narrow the `[compat]` range for `julia`.
│   meets_this_guideline = true
└   message = ""
┌ Info: xvfb: 
└   xvfb = "/usr/bin/xvfb-run"
[ Info: Attempting to `Pkg.add` the package
     Copying registry from `~/work/General/General`
      Copied registry `General` to `/tmp/jl_QQdwIq/registries/General`
[ Info: Attempting to `Pkg.add` package...
    Updating registry at `/tmp/jl_QQdwIq/registries/General`
┌ Error: Some registries failed to update:
│     — `/tmp/jl_QQdwIq/registries/General` — registry dirty
└ @ Pkg.Registry /opt/hostedtoolcache/julia/1.9.2/x64/share/julia/stdlib/v1.9/Pkg/src/Registry/Registry.jl:510
   Resolving package versions...
   Installed Conda ─────────────── v1.9.1
   Installed OpenSSL_jll ───────── v1.1.21+0
   Installed FFTW ──────────────── v1.7.1
   Installed Preferences ───────── v1.4.0
   Installed JSON ──────────────── v0.21.4
   Installed IOCapture ─────────── v0.2.3
   Installed ColorTypes ────────── v0.11.4
   Installed Parsers ───────────── v2.7.1
   Installed FixedPointNumbers ─── v0.8.4
   Installed libsass_jll ───────── v3.6.4+0
   Installed PyCall ────────────── v1.96.1
   Installed DocumenterTools ───── v0.1.17
   Installed Documenter ────────── v0.27.25
   Installed JLLWrappers ───────── v1.4.1
   Installed PrecompileTools ───── v1.1.2
   Installed MKL_jll ───────────── v2023.1.0+0
   Installed VersionParsing ────── v1.3.0
   Installed AbstractTrees ─────── v0.4.4
   Installed AbstractFFTs ──────── v1.4.0
   Installed PyPlot ────────────── v2.11.1
   Installed LaTeXStrings ──────── v1.3.0
   Installed Gumbo ─────────────── v0.8.2
   Installed OpenSSH_jll ───────── v8.9.0+1
   Installed Gumbo_jll ─────────── v0.10.2+0
   Installed Reexport ──────────── v1.2.2
   Installed Colors ────────────── v0.12.10
   Installed FFTW_jll ──────────── v3.3.10+0
   Installed Sass ──────────────── v0.2.0
   Installed MacroTools ────────── v0.5.10
   Installed IntelOpenMP_jll ───── v2023.1.0+0
   Installed DocStringExtensions ─ v0.9.3
   Installed ANSIColoredPrinters ─ v0.0.1
   Installed SeisPlot ──────────── v0.1.1
   Installed SeisMain ──────────── v0.1.1
    Updating `/tmp/jl_QQdwIq/environments/v1.9/Project.toml`
  [00783350] + SeisPlot v0.1.1
    Updating `/tmp/jl_QQdwIq/environments/v1.9/Manifest.toml`
  [a4c015fc] + ANSIColoredPrinters v0.0.1
  [621f4979] + AbstractFFTs v1.4.0
  [1520ce14] + AbstractTrees v0.4.4
  [3da002f7] + ColorTypes v0.11.4
  [5ae59095] + Colors v0.12.10
  [8f4d0f93] + Conda v1.9.1
  [ffbed154] + DocStringExtensions v0.9.3
  [e30172f5] + Documenter v0.27.25
  [35a29f4d] + DocumenterTools v0.1.17
  [7a1cc6ca] + FFTW v1.7.1
  [53c48c17] + FixedPointNumbers v0.8.4
  [708ec375] + Gumbo v0.8.2
  [b5f81e59] + IOCapture v0.2.3
  [692b3bcd] + JLLWrappers v1.4.1
  [682c06a0] + JSON v0.21.4
  [b964fa9f] + LaTeXStrings v1.3.0
  [1914dd2f] + MacroTools v0.5.10
  [69de0a69] + Parsers v2.7.1
  [aea7be01] + PrecompileTools v1.1.2
  [21216c6a] + Preferences v1.4.0
  [438e738f] + PyCall v1.96.1
  [d330b81b] + PyPlot v2.11.1
  [189a3867] + Reexport v1.2.2
  [322a6be2] + Sass v0.2.0
  [5696fd22] + SeisMain v0.1.1
  [00783350] + SeisPlot v0.1.1
  [81def892] + VersionParsing v1.3.0
  [f5851436] + FFTW_jll v3.3.10+0
  [528830af] + Gumbo_jll v0.10.2+0
  [1d5cc7b8] + IntelOpenMP_jll v2023.1.0+0
  [856f044c] + MKL_jll v2023.1.0+0
⌅ [9bd350c2] + OpenSSH_jll v8.9.0+1
⌅ [458c3c95] + OpenSSL_jll v1.1.21+0
  [47bcb7c8] + libsass_jll v3.6.4+0
  [0dad84c5] + ArgTools v1.1.1
  [56f22d72] + Artifacts
  [2a0f44e3] + Base64
  [ade2ca70] + Dates
  [8ba89e20] + Distributed
  [f43a241f] + Downloads v1.6.0
  [7b1f6079] + FileWatching
  [b77e0a4c] + InteractiveUtils
  [4af54fe1] + LazyArtifacts
  [b27032c2] + LibCURL v0.6.3
  [76f85450] + LibGit2
  [8f399da3] + Libdl
  [37e2e46d] + LinearAlgebra
  [56ddb016] + Logging
  [d6f4376e] + Markdown
  [a63ad114] + Mmap
  [ca575930] + NetworkOptions v1.2.0
  [44cfe95a] + Pkg v1.9.2
  [de0858da] + Printf
  [3fa0cd96] + REPL
  [9a3f8284] + Random
  [ea8e919c] + SHA v0.7.0
  [9e88b42a] + Serialization
  [6462fe0b] + Sockets
  [2f01184e] + SparseArrays
  [10745b16] + Statistics v1.9.0
  [fa267f1f] + TOML v1.0.3
  [a4e569a6] + Tar v1.10.0
  [8dfed614] + Test
  [cf7118a7] + UUIDs
  [4ec0a83e] + Unicode
  [e66e0078] + CompilerSupportLibraries_jll v1.0.5+0
  [deac9b47] + LibCURL_jll v7.84.0+0
  [29816b5a] + LibSSH2_jll v1.10.2+0
  [c8ffd9c3] + MbedTLS_jll v2.28.2+0
  [14a3606d] + MozillaCACerts_jll v2022.10.11
  [4536629a] + OpenBLAS_jll v0.3.21+4
  [bea87d4a] + SuiteSparse_jll v5.10.1+6
  [83775a58] + Zlib_jll v1.2.13+0
  [8e850b90] + libblastrampoline_jll v5.8.0+0
  [8e850ede] + nghttp2_jll v1.48.0+0
  [3f19e933] + p7zip_jll v17.4.0+0
        Info Packages marked with ⌅ have new versions available but compatibility constraints restrict them from upgrading. To see why use `status --outdated -m`
    Building Conda ───→ `/tmp/jl_QQdwIq/scratchspaces/44cfe95a-1eb2-52ea-b672-e2afdf69b78f/8c86e48c0db1564a1d49548d3515ced5d604c408/build.log`
    Building PyCall ──→ `/tmp/jl_QQdwIq/scratchspaces/44cfe95a-1eb2-52ea-b672-e2afdf69b78f/43d304ac6f0354755f1d60730ece8c499980f7ba/build.log`
    Building SeisPlot → `/tmp/jl_QQdwIq/scratchspaces/44cfe95a-1eb2-52ea-b672-e2afdf69b78f/4f40cb00468c28b30d07c0fb872f765395a9fdb0/build.log`
[ Info: Successfully `Pkg.add`ed package
[ Info: Successfully `Pkg.add`ed the package
┌ Info: Version can be `Pkg.add`ed
│   meets_this_guideline = true
└   message = ""
[ Info: Attempting to clone...
┌ Info: Code can be downloaded.
│   meets_this_guideline = true
└   message = ""
┌ Info: License check passed; results
│   osi_results =
│    1-element Vector{String}:
│     "MIT license in LICENSE"
└   non_osi_results = String[]
┌ Info: Version has OSI-approved license
│   meets_this_guideline = true
└   message = "Found OSI-approved license(s): MIT license in LICENSE. Found no other licenses."
┌ Info: `src` files and directories names are OK
│   meets_this_guideline = true
└   message = ""
┌ Info: xvfb: 
└   xvfb = "/usr/bin/xvfb-run"
[ Info: Attempting to `import` the package
     Copying registry from `~/work/General/General`
      Copied registry `General` to `/tmp/jl_XSQ4UR/registries/General`
[ Info: Attempting to `Pkg.add` package...
    Updating registry at `/tmp/jl_XSQ4UR/registries/General`
┌ Error: Some registries failed to update:
│     — `/tmp/jl_XSQ4UR/registries/General` — registry dirty
└ @ Pkg.Registry /opt/hostedtoolcache/julia/1.9.2/x64/share/julia/stdlib/v1.9/Pkg/src/Registry/Registry.jl:510
   Resolving package versions...
   Installed Preferences ───────── v1.4.0
   Installed OpenSSL_jll ───────── v1.1.21+0
   Installed JSON ──────────────── v0.21.4
   Installed FFTW ──────────────── v1.7.1
   Installed Conda ─────────────── v1.9.1
   Installed ColorTypes ────────── v0.11.4
   Installed IOCapture ─────────── v0.2.3
   Installed libsass_jll ───────── v3.6.4+0
   Installed Parsers ───────────── v2.7.1
   Installed DocumenterTools ───── v0.1.17
   Installed Documenter ────────── v0.27.25
   Installed PyCall ────────────── v1.96.1
   Installed FixedPointNumbers ─── v0.8.4
   Installed AbstractFFTs ──────── v1.4.0
   Installed PrecompileTools ───── v1.1.2
   Installed VersionParsing ────── v1.3.0
   Installed JLLWrappers ───────── v1.4.1
   Installed PyPlot ────────────── v2.11.1
   Installed MKL_jll ───────────── v2023.1.0+0
   Installed LaTeXStrings ──────── v1.3.0
   Installed AbstractTrees ─────── v0.4.4
   Installed Gumbo ─────────────── v0.8.2
   Installed OpenSSH_jll ───────── v8.9.0+1
   Installed Gumbo_jll ─────────── v0.10.2+0
   Installed Reexport ──────────── v1.2.2
   Installed IntelOpenMP_jll ───── v2023.1.0+0
   Installed MacroTools ────────── v0.5.10
   Installed FFTW_jll ──────────── v3.3.10+0
   Installed Sass ──────────────── v0.2.0
   Installed SeisMain ──────────── v0.1.1
   Installed ANSIColoredPrinters ─ v0.0.1
   Installed Colors ────────────── v0.12.10
   Installed DocStringExtensions ─ v0.9.3
   Installed SeisPlot ──────────── v0.1.1
    Updating `/tmp/jl_XSQ4UR/environments/v1.9/Project.toml`
  [00783350] + SeisPlot v0.1.1
    Updating `/tmp/jl_XSQ4UR/environments/v1.9/Manifest.toml`
  [a4c015fc] + ANSIColoredPrinters v0.0.1
  [621f4979] + AbstractFFTs v1.4.0
  [1520ce14] + AbstractTrees v0.4.4
  [3da002f7] + ColorTypes v0.11.4
  [5ae59095] + Colors v0.12.10
  [8f4d0f93] + Conda v1.9.1
  [ffbed154] + DocStringExtensions v0.9.3
  [e30172f5] + Documenter v0.27.25
  [35a29f4d] + DocumenterTools v0.1.17
  [7a1cc6ca] + FFTW v1.7.1
  [53c48c17] + FixedPointNumbers v0.8.4
  [708ec375] + Gumbo v0.8.2
  [b5f81e59] + IOCapture v0.2.3
  [692b3bcd] + JLLWrappers v1.4.1
  [682c06a0] + JSON v0.21.4
  [b964fa9f] + LaTeXStrings v1.3.0
  [1914dd2f] + MacroTools v0.5.10
  [69de0a69] + Parsers v2.7.1
  [aea7be01] + PrecompileTools v1.1.2
  [21216c6a] + Preferences v1.4.0
  [438e738f] + PyCall v1.96.1
  [d330b81b] + PyPlot v2.11.1
  [189a3867] + Reexport v1.2.2
  [322a6be2] + Sass v0.2.0
  [5696fd22] + SeisMain v0.1.1
  [00783350] + SeisPlot v0.1.1
  [81def892] + VersionParsing v1.3.0
  [f5851436] + FFTW_jll v3.3.10+0
  [528830af] + Gumbo_jll v0.10.2+0
  [1d5cc7b8] + IntelOpenMP_jll v2023.1.0+0
  [856f044c] + MKL_jll v2023.1.0+0
⌅ [9bd350c2] + OpenSSH_jll v8.9.0+1
⌅ [458c3c95] + OpenSSL_jll v1.1.21+0
  [47bcb7c8] + libsass_jll v3.6.4+0
  [0dad84c5] + ArgTools v1.1.1
  [56f22d72] + Artifacts
  [2a0f44e3] + Base64
  [ade2ca70] + Dates
  [8ba89e20] + Distributed
  [f43a241f] + Downloads v1.6.0
  [7b1f6079] + FileWatching
  [b77e0a4c] + InteractiveUtils
  [4af54fe1] + LazyArtifacts
  [b27032c2] + LibCURL v0.6.3
  [76f85450] + LibGit2
  [8f399da3] + Libdl
  [37e2e46d] + LinearAlgebra
  [56ddb016] + Logging
  [d6f4376e] + Markdown
  [a63ad114] + Mmap
  [ca575930] + NetworkOptions v1.2.0
  [44cfe95a] + Pkg v1.9.2
  [de0858da] + Printf
  [3fa0cd96] + REPL
  [9a3f8284] + Random
  [ea8e919c] + SHA v0.7.0
  [9e88b42a] + Serialization
  [6462fe0b] + Sockets
  [2f01184e] + SparseArrays
  [10745b16] + Statistics v1.9.0
  [fa267f1f] + TOML v1.0.3
  [a4e569a6] + Tar v1.10.0
  [8dfed614] + Test
  [cf7118a7] + UUIDs
  [4ec0a83e] + Unicode
  [e66e0078] + CompilerSupportLibraries_jll v1.0.5+0
  [deac9b47] + LibCURL_jll v7.84.0+0
  [29816b5a] + LibSSH2_jll v1.10.2+0
  [c8ffd9c3] + MbedTLS_jll v2.28.2+0
  [14a3606d] + MozillaCACerts_jll v2022.10.11
  [4536629a] + OpenBLAS_jll v0.3.21+4
  [bea87d4a] + SuiteSparse_jll v5.10.1+6
  [83775a58] + Zlib_jll v1.2.13+0
  [8e850b90] + libblastrampoline_jll v5.8.0+0
  [8e850ede] + nghttp2_jll v1.48.0+0
  [3f19e933] + p7zip_jll v17.4.0+0
        Info Packages marked with ⌅ have new versions available but compatibility constraints restrict them from upgrading. To see why use `status --outdated -m`
    Building Conda ───→ `/tmp/jl_XSQ4UR/scratchspaces/44cfe95a-1eb2-52ea-b672-e2afdf69b78f/8c86e48c0db1564a1d49548d3515ced5d604c408/build.log`
    Building PyCall ──→ `/tmp/jl_XSQ4UR/scratchspaces/44cfe95a-1eb2-52ea-b672-e2afdf69b78f/43d304ac6f0354755f1d60730ece8c499980f7ba/build.log`
    Building SeisPlot → `/tmp/jl_XSQ4UR/scratchspaces/44cfe95a-1eb2-52ea-b672-e2afdf69b78f/4f40cb00468c28b30d07c0fb872f765395a9fdb0/build.log`
[ Info: Successfully `Pkg.add`ed package
[ Info: Attempting to `import` package
Precompiling project...
  ✓ Statistics
  ✓ DocStringExtensions
  ✓ VersionParsing
  ✓ AbstractFFTs
  ✓ LaTeXStrings
  ✓ CompilerSupportLibraries_jll
  ✓ ANSIColoredPrinters
  ✓ Reexport
  ✓ MbedTLS_jll
  ✓ MacroTools
  ✓ Zlib_jll
  ✓ SuiteSparse_jll
  ✓ IOCapture
  ✓ Preferences
  ✓ AbstractTrees
  ✓ LibSSH2_jll
  ✓ PrecompileTools
  ✓ JLLWrappers
  ✓ OpenSSL_jll
  ✓ IntelOpenMP_jll
  ✓ FFTW_jll
  ✓ Gumbo_jll
  ✓ FixedPointNumbers
  ✓ libsass_jll
  ✓ MKL_jll
  ✓ OpenSSH_jll
  ✓ Gumbo
  ✓ Sass
  ✓ ColorTypes
  ✓ Colors
  ✓ FFTW
  ✓ Parsers
  ✓ JSON
  ✓ Conda
  ✓ Documenter
  ✓ DocumenterTools
  ✓ SeisMain
  ✓ PyCall
  ✓ PyPlot
  ✗ SeisPlot
  39 dependencies successfully precompiled in 101 seconds

ERROR: The following 1 direct dependency failed to precompile:

SeisPlot [00783350-183d-11e9-0ed7-9f3f458[231](https://github.com/JuliaRegistries/General/actions/runs/5628874608/job/15253230028?pr=88046#step:16:232)83]

Failed to precompile SeisPlot [00783350-183d-11e9-0ed7-9f3f45823183] to "/tmp/jl_XSQ4UR/compiled/v1.9/SeisPlot/jl_JR9fJR".
[ Info: Installing matplotlib via the Conda matplotlib package...
[ Info: Running `conda install -y matplotlib` in root environment

ResolvePackageNotFound: 
  - conda==23.1.0

ERROR: LoadError: InitError: failed process: Process(setenv(`/tmp/jl_XSQ4UR/conda/3/x86_64/bin/conda install -y matplotlib`,["PYTHONIOENCODING=UTF-8", "PATH=/opt/hostedtoolcache/julia/1.9.2/x64/bin:/home/runner/.local/bin:/opt/pipx_bin:/home/runner/.cargo/bin:/home/runner/.config/composer/vendor/bin:/usr/local/.ghcup/bin:/home/runner/.dotnet/tools:/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin", "JULIA_IMAGE_THREADS=1", "***", "CONDA_PREFIX=/tmp/jl_XSQ4UR/conda/3/x86_64", "DISPLAY=:99", "JULIA_LOAD_PATH=/tmp/jl_XSQ4UR/environments/v1.9/Project.toml:/opt/hostedtoolcache/julia/1.9.2/x64/share/julia/stdlib/v1.9", "OPENBLAS_DEFAULT_NUM_THREADS=1", "JULIA_REGISTRYCI_AUTOMERGE=true", "OPENBLAS_NUM_THREADS=1", "XAUTHORITY=/tmp/xvfb-run.RQrCkQ/Xauthority", "HOME=/home/runner", "JULIA_PKG_PRECOMPILE_AUTO=0", "CONDARC=/tmp/jl_XSQ4UR/conda/3/x86_64/condarc-julia.yml", "JULIA_DEPOT_PATH=/tmp/jl_XSQ4UR", "OPENBLAS_MAIN_FREE=1", "R_HOME=*", "JULIA_NUM_THREADS=1"]), ProcessExited(1)) [1]
```