### PR TITLE
env: adding a version upper bound to Conda

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,6 +21,7 @@ FFTW = "1"
 PyCall = "1"
 PyPlot = "2"
 SeisMain = "0.1"
+Conda = "1"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
The Registrator.jl requires upper bounds to all dependencies.